### PR TITLE
feat: add Nix flake and direnv for reproducible dev environment

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+ai-sessions-*.md

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
+fi
+
+use flake . --impure

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Nix / direnv
+.direnv/
+result
+
 # Environment
 .env
 .env.local

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,149 @@
+{
+  description = "claude-devtools - Electron app that visualizes Claude Code sessions";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Nix-provided Electron binary (avoids FHS/NixOS binary issues)
+        electron = pkgs.electron_40;
+
+        # Wrapper that adds NixOS-required flags (sandbox + GPU subprocess fixes)
+        electronWrapper = pkgs.writeShellScriptBin "electron" ''
+          exec ${electron}/libexec/electron/electron \
+            --no-sandbox \
+            --disable-gpu-sandbox \
+            "$@"
+        '';
+
+        # Electron runtime libraries (Linux only)
+        electronLibs = with pkgs; [
+          libx11
+          libxext
+          libxrandr
+          libxcomposite
+          libxcursor
+          libxdamage
+          libxfixes
+          libxi
+          libxrender
+          libxtst
+          libxcb
+          libxshmfence
+          libdrm
+          mesa
+          nss
+          nspr
+          alsa-lib
+          at-spi2-atk
+          atk
+          cups
+          dbus
+          expat
+          glib
+          gtk3
+          pango
+          cairo
+          libxkbcommon
+        ];
+
+        # Dev helper scripts
+        cd-dev = pkgs.writeShellScriptBin "cd-dev" ''
+          echo "Starting dev server with hot reload..."
+          pnpm dev
+        '';
+
+        cd-build = pkgs.writeShellScriptBin "cd-build" ''
+          echo "Building production bundle..."
+          pnpm build
+        '';
+
+        cd-test = pkgs.writeShellScriptBin "cd-test" ''
+          echo "Running tests..."
+          pnpm test
+        '';
+
+        cd-test-watch = pkgs.writeShellScriptBin "cd-test-watch" ''
+          echo "Running tests in watch mode..."
+          pnpm test:watch
+        '';
+
+        cd-check = pkgs.writeShellScriptBin "cd-check" ''
+          echo "Running full quality check (typecheck + lint + test + build)..."
+          pnpm check
+        '';
+
+        cd-fix = pkgs.writeShellScriptBin "cd-fix" ''
+          echo "Auto-fixing lint and formatting..."
+          pnpm fix
+        '';
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "claude-devtools-env";
+
+          buildInputs = with pkgs; [
+            # Core toolchain
+            nodejs_22
+            pnpm
+            git
+            gh
+
+            # Electron from Nix (used via ELECTRON_OVERRIDE_DIST_PATH)
+            electron
+
+            # Native build dependencies
+            gcc
+            gnumake
+            pkg-config
+            python3
+
+            # Dev commands
+            cd-dev
+            cd-build
+            cd-test
+            cd-test-watch
+            cd-check
+            cd-fix
+          ] ++ electronLibs;
+
+          # Tell electron-vite and Electron tooling to use Nix-provided binary
+          # electronWrapper adds --no-sandbox which is required on NixOS
+          ELECTRON_OVERRIDE_DIST_PATH = "${electron}/libexec/electron";
+          ELECTRON_EXEC_PATH = "${electronWrapper}/bin/electron";
+
+          # NixOS requires --no-sandbox for Electron (SUID sandbox incompatible)
+          ELECTRON_DISABLE_SANDBOX = "1";
+
+          shellHook = ''
+            # Electron --no-sandbox flag for NixOS compatibility
+            export ELECTRON_NO_SANDBOX=1
+
+            echo ""
+            echo "  claude-devtools dev shell"
+            echo "  ────────────────────────────────"
+            echo "  Node:     $(node --version)"
+            echo "  pnpm:     $(pnpm --version)"
+            echo "  Electron: ${electron.version}"
+            echo ""
+            echo "  Commands:"
+            echo "    cd-dev         Start dev server with hot reload"
+            echo "    cd-build       Production build"
+            echo "    cd-test        Run all tests"
+            echo "    cd-test-watch  Tests in watch mode"
+            echo "    cd-check       Full quality check"
+            echo "    cd-fix         Auto-fix lint + formatting"
+            echo ""
+          '';
+
+          # Electron needs this to find shared libraries on Linux
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath electronLibs;
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- Add `flake.nix` with Node.js 22, pnpm, Electron 40, and all native Linux/X11 dependencies
- Add `.envrc` with nix-direnv cached evaluation
- Include `electronWrapper` with `--no-sandbox --disable-gpu-sandbox` flags for NixOS Electron compatibility
- Set `ELECTRON_EXEC_PATH` for `electron-vite` binary resolution
- Add helper scripts: `cd-dev`, `cd-build`, `cd-test`, `cd-test-watch`, `cd-check`, `cd-fix`
- Update `.gitignore` for `.direnv/` and `result`

## Test plan
- [x] `nix flake check` passes with no warnings
- [x] Dev shell provides correct versions (Node 22.22.0, pnpm 10.25.0, Electron 40.3.0)
- [x] `pnpm test` — all 499 tests pass inside dev shell
- [x] `pnpm build` — production build succeeds
- [x] `pnpm dev` — Electron launches (no "Electron uninstall" error)
- [ ] Verify full GUI rendering with display (GPU sandbox fix)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)